### PR TITLE
feat(schedules): add speakers section with enhanced card component

### DIFF
--- a/app/components/sections/schedules/speakers.tsx
+++ b/app/components/sections/schedules/speakers.tsx
@@ -26,14 +26,17 @@ export const SpeakersSection = ({ speakers }: SpeakersSectionProps) => {
 		},
 	];
 
+	// Ensure speakers.results exists and is an array
+	const speakersResults = speakers?.results || [];
+
 	// Group speakers from API by speaker_type
-	const shortTalkSpeakers = speakers.results.filter(
+	const shortTalkSpeakers = speakersResults.filter(
 		(speaker) =>
 			speaker.speaker_type?.name?.toLowerCase().includes("short") ?? false,
 	);
 
 	// Regular talk speakers are those that have a speaker_type but are not keynote or short talk
-	const regularTalkSpeakers = speakers.results.filter((speaker) => {
+	const regularTalkSpeakers = speakersResults.filter((speaker) => {
 		const hasType = !!speaker.speaker_type?.name;
 		const isNotKeynote = !speaker.speaker_type?.name
 			?.toLowerCase()
@@ -46,9 +49,14 @@ export const SpeakersSection = ({ speakers }: SpeakersSectionProps) => {
 
 	// Helper function to get full name
 	const getFullName = (speaker: SpeakerData["results"][0]) => {
+		if (!speaker?.user) return "Unknown Speaker";
 		const firstName = speaker.user.first_name || "";
 		const lastName = speaker.user.last_name || "";
-		return `${firstName} ${lastName}`.trim() || speaker.user.username;
+		return (
+			`${firstName} ${lastName}`.trim() ||
+			speaker.user.username ||
+			"Unknown Speaker"
+		);
 	};
 
 	// Map regular and short talk speakers for OurTeamCard
@@ -174,8 +182,8 @@ export const SpeakersSection = ({ speakers }: SpeakersSectionProps) => {
 					</h1>
 				</div>
 
-				<div className="flex justify-center pb-4 px-5 2xl:px-0 overflow-x-hidden">
-					<div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3 sm:gap-x-4 md:gap-x-4 lg:gap-x-6 xl:gap-x-8 gap-y-4 sm:gap-y-5 md:gap-y-6 w-full max-w-7xl justify-items-center">
+				<div className="flex justify-center xl:pb-20 xl:px-28 lg:pb-10 lg:px-24 md:pb-8 md:px-16 px-5 sm:mx-auto 2xl:px-0  overflow-x-hidden">
+					<div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3 sm:gap-x-4 md:gap-x-4 lg:gap-x-6 xl:gap-x-8 gap-y-4 sm:gap-y-5 md:gap-y-6 w-full max-w-7xl sm:mx-auto justify-items-center">
 						{mappedRegularTalkSpeakers.length > 0 ? (
 							mappedRegularTalkSpeakers.map((speaker) => {
 								const { id, ...speakerProps } = speaker;
@@ -206,8 +214,8 @@ export const SpeakersSection = ({ speakers }: SpeakersSectionProps) => {
 					</h1>
 				</div>
 
-				<div className="flex justify-center pb-4 px-5 2xl:px-0 overflow-x-hidden">
-					<div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3 sm:gap-x-4 md:gap-x-4 lg:gap-x-6 xl:gap-x-8 gap-y-4 sm:gap-y-5 md:gap-y-6 w-full max-w-7xl justify-items-center">
+				<div className="flex justify-center xl:pb-20 xl:px-28 lg:pb-10 lg:px-24 md:pb-8 md:px-16 px-5 sm:mx-auto 2xl:px-0  overflow-x-hidden">
+					<div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3 sm:gap-x-4 md:gap-x-4 lg:gap-x-6 xl:gap-x-8 gap-y-4 sm:gap-y-5 md:gap-y-6 w-full max-w-7xl sm:mx-auto justify-items-center">
 						{mappedShortTalkSpeakers.length > 0 ? (
 							mappedShortTalkSpeakers.map((speaker) => {
 								const { id, ...speakerProps } = speaker;
@@ -215,7 +223,7 @@ export const SpeakersSection = ({ speakers }: SpeakersSectionProps) => {
 							})
 						) : (
 							<div className="col-span-full text-center text-gray-500 py-8 h-[500px] flex items-center justify-center">
-								No short talk speakers available
+								No regular talk speakers available
 							</div>
 						)}
 					</div>

--- a/app/components/shared/card/our-team.tsx
+++ b/app/components/shared/card/our-team.tsx
@@ -23,19 +23,19 @@ export const OurTeamCard = ({
 	github,
 }: OurTeamCardProps) => {
 	return (
-		<div className="aspect-24/37 w-72 sm:w-80 md:w-full lg:w-full xl:w-96 flex-shrink-0 bg-white rounded-4xl p-4 sm:p-5 md:p-4 lg:p-5 xl:p-6 pt-6 sm:pt-7 md:pt-6 lg:pt-7 xl:pt-8 border border-black/15 shadow-lg relative overflow-hidden mx-auto sm:mx-auto md:mx-0">
+		<div className="aspect-24/37 w-72 sm:w-80 md:w-full lg:w-64 xl:w-84 flex-shrink-0 bg-white rounded-4xl p-4 sm:p-5 md:p-4 lg:p-5 xl:p-6 pt-6 sm:pt-7 md:pt-6 lg:pt-7 xl:pt-8 border border-black/15 shadow-lg relative overflow-hidden mx-auto sm:mx-auto md:mx-0">
 			<div className="absolute inset-0 bg-[url('/svg/our-team-decoration-orange.svg')] bg-[100%_auto] bg-no-repeat" />
 			<div className="absolute inset-0 bg-[url('/svg/our-team-decoration-blue.svg')] bg-[100%_auto] bg-no-repeat bg-bottom" />
 
 			<div className="relative flex flex-col items-center justify-between h-full">
-				<div className="flex flex-col gap-y-4 sm:gap-y-4 md:gap-y-3 lg:gap-y-4 w-full">
+				<div className="flex flex-col gap-y-4 md:gap-y-1 lg:gap-y-2 w-full">
 					<img
 						src="/images/logo-dark.webp"
 						alt="PyconID 2025"
 						className="h-6 sm:h-8 md:h-6 lg:h-8 xl:h-10 mx-auto mt-4 sm:mt-4 md:mt-1 lg:mt-4 xl:mt-6"
 					/>
 					<div className="relative w-full flex justify-center mt-4 lg:mt-1">
-						<div className="relative w-36 h-36 sm:w-36 sm:h-36 md:w-28 md:h-28 lg:w-40 lg:h-40 xl:w-60 xl:h-60 rounded-full">
+						<div className="relative w-36 h-36 sm:w-36 sm:h-36 md:w-28 md:h-28 lg:w-34 lg:h-34 xl:w-44 xl:h-44 rounded-full">
 							<img
 								src={profile_picture?.trim() || "/images/default-avatar.webp"}
 								alt={name}
@@ -44,18 +44,18 @@ export const OurTeamCard = ({
 						</div>
 					</div>
 
-					<div className="text-center px-2 sm:px-3 md:px-4">
+					<div className="text-center px-2 sm:px-3 md:px-4 lg:px-1">
 						<h1 className="text-xl sm:text-xl md:text-lg lg:text-2xl xl:text-3xl font-bold break-words md:leading-tight">
 							{name}
 						</h1>
-						<p className="font-light text-sm sm:text-sm md:text-sm lg:text-lg xl:text-lg mb-2 sm:mb-3 md:mb-4 lg:mb-4 xl:mb-5 line-clamp-2 break-words">
+						<p className="font-light text-sm sm:text-sm md:text-sm lg:text-sm xl:text-lg mb-2 sm:mb-3 md:mb-4 lg:mb-4 xl:mb-5 line-clamp-2 break-words">
 							{jobTitle}
 							<br /> <span>{affiliation}</span>
 						</p>
 					</div>
 				</div>
 
-				<div className="flex items-center justify-center gap-x-2">
+				<div className="flex items-center justify-center gap-x-2 md:gap-x-1">
 					{instagram_username && (
 						<a
 							href={instagram_username}

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -21,6 +21,7 @@ export default [
 	route("/tiket", "routes/tiket.tsx"),
 	route("/sponsor-us", "routes/sponsor-us.tsx"),
 	route("/schedules", "routes/schedules.tsx"),
+	route("/speakers", "routes/speakers.tsx"),
 	layout("routes/layouts/auth.tsx", [
 		route("/login", "routes/login.tsx"),
 		route("/register", "routes/register.tsx"),

--- a/app/routes/schedules.tsx
+++ b/app/routes/schedules.tsx
@@ -1,10 +1,6 @@
-import { getSpeaker } from "~/api/endpoint/.server/speaker";
-import { getSpeakerSchema } from "~/api/schema/speaker";
 import { Footer } from "~/components/layouts/navigation/footer";
 import { Header } from "~/components/layouts/navigation/header";
 import { SchedulesSection } from "~/components/sections/schedules/schedules";
-import { SpeakersSection } from "~/components/sections/schedules/speakers";
-import type { Route } from "./+types/schedules";
 
 export function meta() {
 	return [
@@ -13,38 +9,11 @@ export function meta() {
 	];
 }
 
-export const loader = async () => {
-	const speakersRes = await getSpeaker({
-		all: true,
-		order_dir: "asc",
-	});
-
-	if (!speakersRes.ok) {
-		console.error(
-			"Failed to fetch speakers data",
-			speakersRes.status,
-			await speakersRes.text(),
-		);
-		throw new Response("Failed to fetch speakers", {
-			status: speakersRes.status,
-		});
-	}
-
-	const speakers = getSpeakerSchema.parse(await speakersRes.json());
-
-	return {
-		speakers,
-	};
-};
-
-export default function Schedules(componentProps: Route.ComponentProps) {
-	const { speakers } = componentProps.loaderData;
-
+export default function Schedules() {
 	return (
 		<main>
 			<Header />
 			<SchedulesSection />
-			<SpeakersSection speakers={speakers} />
 			<Footer />
 		</main>
 	);

--- a/app/routes/speakers.tsx
+++ b/app/routes/speakers.tsx
@@ -1,0 +1,86 @@
+import { getSpeaker } from "~/api/endpoint/.server/speaker";
+import { getSpeakerSchema } from "~/api/schema/speaker";
+import { Footer } from "~/components/layouts/navigation/footer";
+import { Header } from "~/components/layouts/navigation/header";
+import { SpeakersSection } from "~/components/sections/schedules/speakers";
+
+export function meta() {
+	return [
+		{ title: "PyCon ID 2025 Speakers" },
+		{ name: "Speakers", content: "Speakers page" },
+	];
+}
+
+export const loader = async () => {
+	try {
+		const speakersRes = await getSpeaker({
+			all: true,
+			order_dir: "asc",
+		});
+
+		if (!speakersRes.ok) {
+			console.error(
+				"Failed to fetch speakers data",
+				speakersRes.status,
+				await speakersRes.text(),
+			);
+			// Return empty data structure instead of throwing error
+			return {
+				speakers: {
+					page: 1,
+					page_size: 0,
+					count: 0,
+					page_count: 0,
+					results: [],
+				},
+			};
+		}
+
+		const jsonData = await speakersRes.json();
+
+		// Handle empty or invalid response
+		if (!jsonData || !jsonData.results || jsonData.results.length === 0) {
+			return {
+				speakers: {
+					page: jsonData?.page || 1,
+					page_size: jsonData?.page_size || 0,
+					count: jsonData?.count || 0,
+					page_count: jsonData?.page_count || 0,
+					results: [],
+				},
+			};
+		}
+
+		const speakers = getSpeakerSchema.parse(jsonData);
+
+		return {
+			speakers,
+		};
+	} catch (error) {
+		console.error("Error parsing speakers data:", error);
+		// Return empty data structure on parsing error
+		return {
+			speakers: {
+				page: 1,
+				page_size: 0,
+				count: 0,
+				page_count: 0,
+				results: [],
+			},
+		};
+	}
+};
+
+export default function Speakers(componentProps: {
+	loaderData: Awaited<ReturnType<typeof loader>>;
+}) {
+	const { speakers } = componentProps.loaderData;
+
+	return (
+		<main>
+			<Header />
+			<SpeakersSection speakers={speakers} />
+			<Footer />
+		</main>
+	);
+}


### PR DESCRIPTION
Changes:
- Add SpeakersSection component to regular talk and short talk speakers
- Enhance OurTeamCard component to support speaker data (name, jobTitle, affiliation, profile_picture, social links)
- Add responsive design improvements to OurTeamCard
- Add default avatar image for speakers without profile picture
- Integrate speakers data fetching in schedules route loader

<img width="1395" height="784" alt="SCR-20251201-pfvz" src="https://github.com/user-attachments/assets/8a5eb83c-03c5-4918-ac77-8d99c7893771" />
<img width="1351" height="783" alt="SCR-20251201-pgqv" src="https://github.com/user-attachments/assets/e75ba3f4-501b-4a61-82ed-8abb31baeff0" />

Closes #115 
