### PR TITLE
Fix logout problem in streaming

### DIFF
--- a/app/routes/streaming.tsx
+++ b/app/routes/streaming.tsx
@@ -41,6 +41,11 @@ export const loader = async ({ params, request }: Route.LoaderArgs) => {
 		request,
 		id: scheduleDetail.stream.id,
 	});
+
+	if (dataStreamDetail.status === 401) {
+		return await authenticator.logout(request, { redirectTo: "/login" });
+	}
+
 	if (dataStreamDetail.status !== 200) {
 		return redirect("/not-found");
 	}


### PR DESCRIPTION
Reroute to /login when server respond with 401 in `/streaming/${id}` end point in the backend.